### PR TITLE
error handling, non-enabled containers

### DIFF
--- a/tunnel-manager/main.py
+++ b/tunnel-manager/main.py
@@ -74,7 +74,6 @@ def main():
                 cf_manager.update_tunnel_config(labels)
 
         # Send the final tunnel configuration update
-        logger.info("Pushing final tunnel configuration")
         cf_manager.push_tunnel_config()
 
     except Exception as e:


### PR DESCRIPTION
This pull request focuses on enhancing the tunnel and DNS configuration update processes in the `tunnel-manager/cloudflare_manager.py` file. The changes introduce checks for an 'enabled' label before proceeding with updates and ensure that the methods return a boolean to indicate if an update occurred.

Enhancements to configuration update processes:

* Added a check for the 'enabled' label in `update_tunnel_config`, `push_tunnel_config`, and `update_dns_record` methods to ensure updates are only performed when enabled.
* Modified `update_dns_record` to return `True` if an update occurs, allowing the caller to determine if an update was made. 
* Updated `handle_container_update` to check if DNS or tunnel updates were made before pushing the tunnel configuration.
* Removed redundant logging statement for pushing the final tunnel configuration.